### PR TITLE
Template variables handling

### DIFF
--- a/resources/templates.xml
+++ b/resources/templates.xml
@@ -6,6 +6,7 @@
         <template regexp="^.*(public|protected|private)*.+interface\s+\w+.*">
 /**\n
  * The interface ${name}.\n
+ * @since ${todayDate}\n
     &lt;#if element.typeParameters?has_content&gt;
         * \n
     &lt;/#if&gt;
@@ -21,12 +22,14 @@
         <template regexp="^.*(public|protected|private)*.+enum\s+\w+.*">
 /**\n
  * The enum ${name}.\n
+ * @since ${todayDate}\n
  */
         </template>
 
         <template regexp="^.*(public|protected|private)*.+class\s+\w+.*">
 /**\n
  * The type ${name}.\n
+ * @since ${todayDate}\n
     &lt;#if element.typeParameters?has_content&gt;
         * \n
     &lt;/#if&gt;
@@ -42,6 +45,7 @@
         <template regexp=".+">
 /**\n
  * The type ${name}.\n
+ * @since ${todayDate}\n
  */
         </template>
 

--- a/src/com/github/setial/intellijjavadocs/configuration/impl/JavaDocConfigurationImpl.java
+++ b/src/com/github/setial/intellijjavadocs/configuration/impl/JavaDocConfigurationImpl.java
@@ -168,7 +168,8 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration, Configura
             settings.getTemplateSettings().setClassTemplates(templateManager.getClassTemplates());
             settings.getTemplateSettings().setConstructorTemplates(templateManager.getConstructorTemplates());
             settings.getTemplateSettings().setMethodTemplates(templateManager.getMethodTemplates());
-            settings.getTemplateSettings().setFieldTemplates(templateManager.getFieldTemplates());
+	        settings.getTemplateSettings().setFieldTemplates(templateManager.getFieldTemplates());
+	        settings.getTemplateSettings().setVariables(templateManager.getVariables());
         }
         return settings;
     }
@@ -179,6 +180,7 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration, Configura
             templateManager.setConstructorTemplates(settings.getTemplateSettings().getConstructorTemplates());
             templateManager.setMethodTemplates(settings.getTemplateSettings().getMethodTemplates());
             templateManager.setFieldTemplates(settings.getTemplateSettings().getFieldTemplates());
+            templateManager.setVariables(settings.getTemplateSettings().getVariables());
         } catch (SetupTemplateException e) {
             LOGGER.error(e);
             Messages.showErrorDialog("Javadocs plugin is not available, cause: " + e.getMessage(), "Javadocs plugin");

--- a/src/com/github/setial/intellijjavadocs/generator/impl/AbstractJavaDocGenerator.java
+++ b/src/com/github/setial/intellijjavadocs/generator/impl/AbstractJavaDocGenerator.java
@@ -17,10 +17,12 @@ import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.javadoc.PsiDocComment;
+import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +33,8 @@ import java.util.Map;
  * @author Sergey Timofiychuk
  */
 public abstract class AbstractJavaDocGenerator<T extends PsiElement> implements JavaDocGenerator<T> {
+
+    public static final String DATE_FORMAT = "dateFormat";
 
     private DocTemplateManager docTemplateManager;
     private DocTemplateProcessor docTemplateProcessor;
@@ -144,10 +148,15 @@ public abstract class AbstractJavaDocGenerator<T extends PsiElement> implements 
      */
     protected Map<String, Object> getDefaultParameters(PomNamedTarget element) {
         Map<String, Object> params = new HashMap<String, Object>();
+        params.put(DATE_FORMAT, "yyyy-MM-dd");
         params.put("element", element);
         params.put("name", getDocTemplateProcessor().buildDescription(element.getName(), true));
         params.put("partName", getDocTemplateProcessor().buildPartialDescription(element.getName()));
         params.put("splitNames", StringUtils.splitByCharacterTypeCamelCase(element.getName()));
+        for (Map.Entry<String, String> variable: getDocTemplateManager().getVariables().entrySet()) {
+            params.put(variable.getKey(), variable.getValue());
+        }
+        params.put("todayDate", DateFormatUtils.format(new Date(), params.get(DATE_FORMAT).toString()));
         return params;
     }
 

--- a/src/com/github/setial/intellijjavadocs/model/JavaDoc.java
+++ b/src/com/github/setial/intellijjavadocs/model/JavaDoc.java
@@ -1,6 +1,7 @@
 package com.github.setial.intellijjavadocs.model;
 
 import com.github.setial.intellijjavadocs.utils.JavaDocUtils;
+import org.apache.commons.logging.LogFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -54,7 +55,9 @@ public class JavaDoc {
      */
     @NotNull
     public String toJavaDoc() {
-        return JavaDocUtils.convertJavaDoc(this);
+        String javaDoc = JavaDocUtils.convertJavaDoc(this);
+        LogFactory.getLog(this.getClass()).debug("Generated javadoc: " + javaDoc);
+        return javaDoc;
     }
 
 }

--- a/src/com/github/setial/intellijjavadocs/model/settings/JavaDocSettings.java
+++ b/src/com/github/setial/intellijjavadocs/model/settings/JavaDocSettings.java
@@ -29,7 +29,9 @@ public class JavaDocSettings implements Serializable {
     private static final String FIELD = "FIELD";
     private static final String FIELDS = "FIELDS";
     private static final String METHOD = "METHOD";
-    private static final String METHODS = "METHODS";
+	private static final String METHODS = "METHODS";
+	private static final String VARIABLE = "VARIABLE";
+	private static final String VARIABLES = "VARIABLES";
 
     private GeneralSettings generalSettings = new GeneralSettings();
     private TemplateSettings templateSettings = new TemplateSettings();
@@ -59,7 +61,8 @@ public class JavaDocSettings implements Serializable {
             templateSettings.setClassTemplates(XmlUtils.getMap(templates, CLASSES, CLASS));
             templateSettings.setConstructorTemplates(XmlUtils.getMap(templates, CONSTRUCTORS, CONSTRUCTOR));
             templateSettings.setFieldTemplates(XmlUtils.getMap(templates, FIELDS, FIELD));
-            templateSettings.setMethodTemplates(XmlUtils.getMap(templates, METHODS, METHOD));
+	        templateSettings.setMethodTemplates(XmlUtils.getMap(templates, METHODS, METHOD));
+	        templateSettings.setVariables(XmlUtils.getMap(templates, VARIABLES, VARIABLE));
         }
     }
 
@@ -82,7 +85,8 @@ public class JavaDocSettings implements Serializable {
         templates.addContent(XmlUtils.getElement(CLASSES, CLASS, templateSettings.getClassTemplates()));
         templates.addContent(XmlUtils.getElement(CONSTRUCTORS, CONSTRUCTOR, templateSettings.getConstructorTemplates()));
         templates.addContent(XmlUtils.getElement(METHODS, METHOD, templateSettings.getMethodTemplates()));
-        templates.addContent(XmlUtils.getElement(FIELDS, FIELD, templateSettings.getFieldTemplates()));
+	    templates.addContent(XmlUtils.getElement(FIELDS, FIELD, templateSettings.getFieldTemplates()));
+	    templates.addContent(XmlUtils.getElement(VARIABLES, VARIABLE, templateSettings.getVariables()));
     }
 
     /**

--- a/src/com/github/setial/intellijjavadocs/model/settings/TemplateSettings.java
+++ b/src/com/github/setial/intellijjavadocs/model/settings/TemplateSettings.java
@@ -7,6 +7,7 @@ import java.util.Map;
  * The type Template settings.
  *
  * @author Sergey Timofiychuk
+ * @since 2015 -06-09
  */
 public class TemplateSettings {
 
@@ -14,77 +15,95 @@ public class TemplateSettings {
     private Map<String, String> fieldTemplates = new LinkedHashMap<String, String>();
     private Map<String, String> methodTemplates = new LinkedHashMap<String, String>();
     private Map<String, String> constructorTemplates = new LinkedHashMap<String, String>();
+	private Map<String, String> variables = new LinkedHashMap<String, String>();
 
-    /**
-     * Gets class templates.
-     *
-     * @return the class templates
-     */
-    public Map<String, String> getClassTemplates() {
+	/**
+	 * Gets class templates.
+	 *
+	 * @return the class templates
+	 */
+	public Map<String, String> getClassTemplates() {
         return classTemplates;
     }
 
-    /**
-     * Sets class templates.
-     *
-     * @param classTemplates the class templates
-     */
-    public void setClassTemplates(Map<String, String> classTemplates) {
+	/**
+	 * Sets class templates.
+	 *
+	 * @param classTemplates the class templates
+	 */
+	public void setClassTemplates(Map<String, String> classTemplates) {
         this.classTemplates = classTemplates;
     }
 
-    /**
-     * Gets constructor templates.
-     *
-     * @return the constructor templates
-     */
-    public Map<String, String> getConstructorTemplates() {
+	/**
+	 * Gets constructor templates.
+	 *
+	 * @return the constructor templates
+	 */
+	public Map<String, String> getConstructorTemplates() {
         return constructorTemplates;
     }
 
-    /**
-     * Sets constructor templates.
-     *
-     * @param constructorTemplates the constructor templates
-     */
-    public void setConstructorTemplates(Map<String, String> constructorTemplates) {
+	/**
+	 * Sets constructor templates.
+	 *
+	 * @param constructorTemplates the constructor templates
+	 */
+	public void setConstructorTemplates(Map<String, String> constructorTemplates) {
         this.constructorTemplates = constructorTemplates;
     }
 
-    /**
-     * Gets field templates.
-     *
-     * @return the field templates
-     */
-    public Map<String, String> getFieldTemplates() {
+	/**
+	 * Gets field templates.
+	 *
+	 * @return the field templates
+	 */
+	public Map<String, String> getFieldTemplates() {
         return fieldTemplates;
     }
 
-    /**
-     * Sets field templates.
-     *
-     * @param fieldTemplates the field templates
-     */
-    public void setFieldTemplates(Map<String, String> fieldTemplates) {
+	/**
+	 * Sets field templates.
+	 *
+	 * @param fieldTemplates the field templates
+	 */
+	public void setFieldTemplates(Map<String, String> fieldTemplates) {
         this.fieldTemplates = fieldTemplates;
     }
 
-    /**
-     * Gets method templates.
-     *
-     * @return the method templates
-     */
-    public Map<String, String> getMethodTemplates() {
+	/**
+	 * Gets method templates.
+	 *
+	 * @return the method templates
+	 */
+	public Map<String, String> getMethodTemplates() {
         return methodTemplates;
     }
 
-    /**
-     * Sets method templates.
-     *
-     * @param methodTemplates the method templates
-     */
-    public void setMethodTemplates(Map<String, String> methodTemplates) {
+	/**
+	 * Sets method templates.
+	 *
+	 * @param methodTemplates the method templates
+	 */
+	public void setMethodTemplates(Map<String, String> methodTemplates) {
         this.methodTemplates = methodTemplates;
     }
 
+	/**
+	 * Gets variables.
+	 *
+	 * @return the variables
+	 */
+	public Map<String, String> getVariables() {
+		return variables;
+	}
+
+	/**
+	 * Sets variables.
+	 *
+	 * @param variables the variables
+	 */
+	public void setVariables(Map<String, String> variables) {
+		this.variables = variables;
+	}
 }

--- a/src/com/github/setial/intellijjavadocs/template/DocTemplateManager.java
+++ b/src/com/github/setial/intellijjavadocs/template/DocTemplateManager.java
@@ -109,4 +109,19 @@ public interface DocTemplateManager extends ApplicationComponent {
      */
     void setFieldTemplates(@NotNull Map<String, String> templates);
 
+	/**
+	 * Gets variables.
+	 *
+	 * @return the variables
+	 */
+	@NotNull
+	Map<String, String> getVariables();
+
+	/**
+	 * Sets variables.
+	 *
+	 * @param variables the variables
+	 */
+	void setVariables(@NotNull Map<String, String> variables);
+
 }

--- a/src/com/github/setial/intellijjavadocs/template/impl/DocTemplateManagerImpl.java
+++ b/src/com/github/setial/intellijjavadocs/template/impl/DocTemplateManagerImpl.java
@@ -46,12 +46,14 @@ public class DocTemplateManagerImpl implements DocTemplateManager {
     private static final String CLASS = "class";
     private static final String FIELD = "field";
     private static final String METHOD = "method";
+    private static final String VARIABLES = "variables";
     private static final String CONSTRUCTOR = "constructor";
 
     private Map<String, Template> classTemplates = new LinkedHashMap<String, Template>();
     private Map<String, Template> fieldTemplates = new LinkedHashMap<String, Template>();
     private Map<String, Template> methodTemplates = new LinkedHashMap<String, Template>();
-    private Map<String, Template> constructorTemplates = new LinkedHashMap<String, Template>();
+	private Map<String, Template> constructorTemplates = new LinkedHashMap<String, Template>();
+	private Map<String, Template> templateVariables = new LinkedHashMap<String, Template>();
 
     private Configuration config;
     private StringTemplateLoader templateLoader;
@@ -181,6 +183,22 @@ public class DocTemplateManagerImpl implements DocTemplateManager {
         setupTemplates(templates, constructorTemplates, CONSTRUCTOR);
     }
 
+	@NotNull
+	@Override
+	public Map<String, String> getVariables() {
+		Map<String, String> templates = new LinkedHashMap<String, String>();
+		for (Entry<String, Template> entry : templateVariables.entrySet()) {
+			String template = extractTemplate(entry.getValue());
+			templates.put(entry.getKey(), template);
+		}
+		return templates;
+	}
+
+	@Override
+	public void setVariables(@NotNull Map<String, String> variables) {
+		setupTemplates(variables, templateVariables, VARIABLES);
+	}
+
     @Override
     public void setMethodTemplates(@NotNull Map<String, String> templates) {
         setupTemplates(templates, methodTemplates, METHOD);
@@ -191,7 +209,7 @@ public class DocTemplateManagerImpl implements DocTemplateManager {
         setupTemplates(templates, fieldTemplates, FIELD);
     }
 
-    private void readTemplates(Element document, String elementName, Map<String, Template> templates)
+	private void readTemplates(Element document, String elementName, Map<String, Template> templates)
             throws IOException {
         Element root = document.getChild(elementName);
         @SuppressWarnings("unchecked")

--- a/src/com/github/setial/intellijjavadocs/template/impl/DocTemplateProcessorImpl.java
+++ b/src/com/github/setial/intellijjavadocs/template/impl/DocTemplateProcessorImpl.java
@@ -1,13 +1,10 @@
 package com.github.setial.intellijjavadocs.template.impl;
 
 import com.github.setial.intellijjavadocs.exception.SetupTemplateException;
-import com.github.setial.intellijjavadocs.exception.TemplateNotFoundException;
 import com.github.setial.intellijjavadocs.template.DocTemplateProcessor;
 import com.github.setial.intellijjavadocs.utils.XmlUtils;
-import freemarker.template.Template;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -48,7 +45,7 @@ public class DocTemplateProcessorImpl implements DocTemplateProcessor {
 
     @NotNull
     @Override
-    public String merge(@NotNull Template template, @NotNull Map<String, Object> params) {
+    public String merge(@NotNull freemarker.template.Template template, @NotNull Map<String, Object> params) {
         StringWriter writer = new StringWriter();
         try {
             template.process(params, writer);

--- a/src/com/github/setial/intellijjavadocs/transformation/JavaDocBuilder.java
+++ b/src/com/github/setial/intellijjavadocs/transformation/JavaDocBuilder.java
@@ -3,6 +3,7 @@ package com.github.setial.intellijjavadocs.transformation;
 import com.github.setial.intellijjavadocs.model.JavaDoc;
 import com.github.setial.intellijjavadocs.model.JavaDocElements;
 import com.github.setial.intellijjavadocs.model.JavaDocTag;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 /**
  * The type Java doc builder.
@@ -121,7 +123,10 @@ public class JavaDocBuilder {
             builder.append(tag.getValue());
         }
 
-        builder.append(JavaDocElements.WHITE_SPACE.getPresentation());
+        String startsWithCharacterPattern = "[\\w.,'].*";
+        if (CollectionUtils.isNotEmpty(tag.getDescription()) && Pattern.matches(startsWithCharacterPattern, tag.getDescription().iterator().next())) {
+            builder.append(JavaDocElements.WHITE_SPACE.getPresentation());
+        }
         addTagDescription(tag.getDescription());
         return this;
     }

--- a/src/com/github/setial/intellijjavadocs/ui/component/TemplateConfigDialog.java
+++ b/src/com/github/setial/intellijjavadocs/ui/component/TemplateConfigDialog.java
@@ -13,6 +13,8 @@ import javax.swing.JTextField;
 import java.awt.BorderLayout;
 import java.awt.Insets;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -27,21 +29,16 @@ public class TemplateConfigDialog extends DialogWrapper {
 
     private JTextField nameField;
     private JTextArea templateField;
-
-    /**
-     * Instantiates a new Template config dialog.
-     */
-    public TemplateConfigDialog() {
-        this(null);
-    }
+    private java.util.List<String> columnNames;
 
     /**
      * Instantiates a new Template config dialog.
      *
      * @param model the model
      */
-    public TemplateConfigDialog(Entry<String, String> model) {
+    public TemplateConfigDialog(List<String> columnNames, Entry<String, String> model) {
         super(true);
+        this.columnNames = columnNames;
         if (model != null) {
             Map<String, String> modelCopy = new HashMap<String, String>();
             modelCopy.put(model.getKey(), model.getValue());
@@ -67,12 +64,14 @@ public class TemplateConfigDialog extends DialogWrapper {
         JPanel panel = new JPanel(new BorderLayout());
         panel.setLayout(new GridLayoutManager(2, 1, new Insets(10, 10, 10, 10), -1, -1));
 
+        Iterator<String> columnNamesIter = columnNames.iterator();
+
         nameField = new JTextField();
         if (model != null) {
             nameField.setText(model.getKey());
         }
         JPanel namePanel = new JPanel(new BorderLayout());
-        namePanel.setBorder(IdeBorderFactory.createTitledBorder("Template regexp", false, new Insets(0, 0, 10, 0)));
+        namePanel.setBorder(IdeBorderFactory.createTitledBorder(columnNamesIter.next(), false, new Insets(0, 0, 10, 0)));
         namePanel.add(nameField, BorderLayout.CENTER);
 
         templateField = new JTextArea();
@@ -80,7 +79,7 @@ public class TemplateConfigDialog extends DialogWrapper {
             templateField.setText(model.getValue());
         }
         JPanel templatePanel = new JPanel(new BorderLayout());
-        templatePanel.setBorder(IdeBorderFactory.createTitledBorder("Template content", false, new Insets(0, 0, 0, 0)));
+        templatePanel.setBorder(IdeBorderFactory.createTitledBorder(columnNamesIter.next(), false, new Insets(0, 0, 0, 0)));
         templatePanel.add(templateField, BorderLayout.CENTER);
 
         panel.add(namePanel, getConstraints(0, 0));

--- a/src/com/github/setial/intellijjavadocs/ui/component/TemplatesTable.java
+++ b/src/com/github/setial/intellijjavadocs/ui/component/TemplatesTable.java
@@ -13,13 +13,18 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import java.awt.Component;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.Enumeration;
 import java.util.EventObject;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 /**
@@ -30,6 +35,7 @@ import java.util.Map.Entry;
 public class TemplatesTable extends JBTable {
 
     private List<Entry<String, String>> settings;
+    private List<String> columnNames;
 
     /**
      * Instantiates a new Templates table.
@@ -37,12 +43,13 @@ public class TemplatesTable extends JBTable {
      * @param model the model
      */
     @SuppressWarnings("unchecked")
-    public TemplatesTable(Map<String, String> model) {
+    public TemplatesTable(Map<String, String> model, List<String> columnNames) {
+        this.columnNames = columnNames;
         setStriped(true);
         setAutoResizeMode(AUTO_RESIZE_ALL_COLUMNS);
         settings = new LinkedList<Entry<String, String>>();
         CollectionUtils.addAll(settings, model.entrySet().toArray(new Entry[model.entrySet().size()]));
-        setModel(new TableModel());
+        setModel(new TableModel(columnNames));
         Enumeration<TableColumn> columns = getColumnModel().getColumns();
         while (columns.hasMoreElements()) {
             columns.nextElement().setCellRenderer(new FieldRenderer());
@@ -82,7 +89,7 @@ public class TemplatesTable extends JBTable {
                 return false;
             }
         }
-        TemplateConfigDialog dialog = new TemplateConfigDialog(settings.get(row));
+        TemplateConfigDialog dialog = new TemplateConfigDialog(columnNames, settings.get(row));
         dialog.show();
         if (dialog.isOK()) {
             settings.set(row, dialog.getModel());
@@ -96,11 +103,10 @@ public class TemplatesTable extends JBTable {
 
         /**
          * Instantiates a new Table model.
+         * @param columnNamesParam
          */
-        public TableModel() {
-            columnNames = new LinkedList<String>();
-            columnNames.add("Regular expression");
-            columnNames.add("Preview");
+        public TableModel(List<String> columnNamesParam) {
+            this.columnNames = columnNamesParam;
         }
 
         @Override
@@ -110,7 +116,7 @@ public class TemplatesTable extends JBTable {
 
         @Override
         public void addRow() {
-            TemplateConfigDialog dialog = new TemplateConfigDialog();
+            TemplateConfigDialog dialog = new TemplateConfigDialog(columnNames, null);
             dialog.show();
             if (dialog.isOK()) {
                 settings.add(dialog.getModel());

--- a/src/com/github/setial/intellijjavadocs/ui/settings/ConfigPanel.java
+++ b/src/com/github/setial/intellijjavadocs/ui/settings/ConfigPanel.java
@@ -21,7 +21,8 @@ import javax.swing.JTabbedPane;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Insets;
-import java.util.Map;
+import java.util.*;
+import java.util.List;
 import java.util.Map.Entry;
 
 /**
@@ -56,6 +57,7 @@ public class ConfigPanel extends JPanel {
     private TemplatesTable constructorTemplatesTable;
     private TemplatesTable methodTemplatesTable;
     private TemplatesTable fieldTemplatesTable;
+    private TemplatesTable variablesTable;
 
     /**
      * Instantiates a new Config panel.
@@ -108,6 +110,8 @@ public class ConfigPanel extends JPanel {
                 settings.getTemplateSettings().getMethodTemplates());
         result = result || checkIfTableContentModified(fieldTemplatesTable.getSettings(),
                 settings.getTemplateSettings().getFieldTemplates());
+        result = result || checkIfTableContentModified(variablesTable.getSettings(),
+                settings.getTemplateSettings().getVariables());
 
         return result;
     }
@@ -158,6 +162,7 @@ public class ConfigPanel extends JPanel {
         settings.getTemplateSettings().setConstructorTemplates(constructorTemplatesTable.getSettings());
         settings.getTemplateSettings().setMethodTemplates(methodTemplatesTable.getSettings());
         settings.getTemplateSettings().setFieldTemplates(fieldTemplatesTable.getSettings());
+        settings.getTemplateSettings().setVariables(variablesTable.getSettings());
     }
 
     /**
@@ -213,6 +218,7 @@ public class ConfigPanel extends JPanel {
         constructorTemplatesTable.setSettingsModel(settings.getTemplateSettings().getConstructorTemplates());
         methodTemplatesTable.setSettingsModel(settings.getTemplateSettings().getMethodTemplates());
         fieldTemplatesTable.setSettingsModel(settings.getTemplateSettings().getFieldTemplates());
+        variablesTable.setSettingsModel(settings.getTemplateSettings().getVariables());
     }
 
     /**
@@ -257,13 +263,16 @@ public class ConfigPanel extends JPanel {
     }
 
     private void setupTemplatesPanel() {
-        classTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getClassTemplates());
+        List<String> defaultColumnNames = Arrays.asList(new String[]{"Regular expression", "Preview"});
+        List<String> variablesColumnNames = Arrays.asList(new String[]{"Key", "Value"});
+
+        classTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getClassTemplates(), defaultColumnNames);
         JPanel classTemplatesLocalPanel = ToolbarDecorator.createDecorator(classTemplatesTable).createPanel();
         JPanel classPanel = new JPanel(new BorderLayout());
         classPanel.setBorder(IdeBorderFactory.createTitledBorder("Class level", false, new Insets(0, 0, 10, 0)));
         classPanel.add(classTemplatesLocalPanel, BorderLayout.CENTER);
 
-        constructorTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getConstructorTemplates());
+        constructorTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getConstructorTemplates(), defaultColumnNames);
         JPanel constructorTemplatesLocalPanel =
                 ToolbarDecorator.createDecorator(constructorTemplatesTable).createPanel();
         JPanel constructorPanel = new JPanel(new BorderLayout());
@@ -271,25 +280,32 @@ public class ConfigPanel extends JPanel {
                 new Insets(0, 0, 10, 0)));
         constructorPanel.add(constructorTemplatesLocalPanel, BorderLayout.CENTER);
 
-        methodTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getMethodTemplates());
+        methodTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getMethodTemplates(), defaultColumnNames);
         JPanel methodTemplatesLocalPanel = ToolbarDecorator.createDecorator(methodTemplatesTable).createPanel();
         JPanel methodPanel = new JPanel(new BorderLayout());
         methodPanel.setBorder(IdeBorderFactory.createTitledBorder("Method level", false, new Insets(0, 0, 10, 0)));
         methodPanel.add(methodTemplatesLocalPanel, BorderLayout.CENTER);
 
-        fieldTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getFieldTemplates());
+        fieldTemplatesTable = new TemplatesTable(settings.getTemplateSettings().getFieldTemplates(), defaultColumnNames);
         JPanel fieldTemplatesLocalPanel = ToolbarDecorator.createDecorator(fieldTemplatesTable).createPanel();
         JPanel fieldPanel = new JPanel(new BorderLayout());
         fieldPanel.setBorder(IdeBorderFactory.createTitledBorder("Field level", false, new Insets(0, 0, 0, 0)));
         fieldPanel.add(fieldTemplatesLocalPanel, BorderLayout.CENTER);
 
+        variablesTable = new TemplatesTable(settings.getTemplateSettings().getVariables(), variablesColumnNames);
+        JPanel variablesLocalPanel = ToolbarDecorator.createDecorator(variablesTable).createPanel();
+        JPanel variablesPanel = new JPanel(new BorderLayout());
+        variablesPanel.setBorder(IdeBorderFactory.createTitledBorder("Additional variables", false, new Insets(0, 0, 0, 0)));
+        variablesPanel.add(variablesLocalPanel, BorderLayout.CENTER);
+
         JPanel templatesPanel = new JPanel();
-        templatesPanel.setLayout(new GridLayoutManager(4, 1, new Insets(10, 10, 10, 10), -1, -1));
+        templatesPanel.setLayout(new GridLayoutManager(5, 1, new Insets(10, 10, 10, 10), -1, -1));
 
         templatesPanel.add(classPanel, getConstraints(0, 0));
         templatesPanel.add(constructorPanel, getConstraints(1, 0));
         templatesPanel.add(methodPanel, getConstraints(2, 0));
         templatesPanel.add(fieldPanel, getConstraints(3, 0));
+        templatesPanel.add(variablesPanel, getConstraints(4, 0));
         tabbedPane.addTab("Templates", templatesPanel);
     }
 

--- a/src/com/github/setial/intellijjavadocs/utils/JavaDocUtils.java
+++ b/src/com/github/setial/intellijjavadocs/utils/JavaDocUtils.java
@@ -11,6 +11,7 @@ import com.intellij.psi.impl.source.javadoc.PsiDocTagValueImpl;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.psi.javadoc.PsiDocTag;
 import com.intellij.psi.javadoc.PsiDocTagValue;
+import com.intellij.psi.javadoc.PsiDocToken;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
How about some additional variables available to the developer? For example - following template:
/**\n
 * The interface ${name}.\n
 * @author ${author}\n
 * @since ${todayDate}\n
 */
could result in Javadoc:
/**
 * The type blablabla.
 *
 * @author John Doe
 * @since 2016-04-26
 */
Today date is added automatically, and additional variables, like ${author} can be added in the Settings menu.

Also - I made a change in JavaDocBuilder that makes date 2016-04-26 formatted correctly, without space in between.
