### PR TITLE
Add support for IntelliJ IDEA 2024.3; refactor build scripts and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 out
 build
 intellij-community
+.intellijPlatform

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,51 @@
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 plugins {
     id("idea")
-    id("org.jetbrains.intellij") version "1.15.0"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
 }
-
 group "com.github.setial"
-version "4.1.3"
 
-sourceCompatibility = 17
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+}
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+    dependencies {
+        implementation 'commons-beanutils:commons-beanutils:1.9.4'
+        implementation 'org.apache.commons:commons-collections4:4.4'
+        implementation 'org.apache.commons:commons-lang3:3.9'
+        implementation 'commons-logging:commons-logging:1.2'
+        implementation 'org.freemarker:freemarker:2.3.32'
+        testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+
+        intellijPlatform {
+            intellijIdeaCommunity("2024.3.4")
+
+            bundledPlugin("com.intellij.java")
+
+            testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
+        }
+    }
 }
 
-dependencies {
-    implementation 'commons-beanutils:commons-beanutils:1.9.4'
-    implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation 'commons-logging:commons-logging:1.2'
-    implementation 'org.freemarker:freemarker:2.3.32'
-    testImplementation group: 'junit', name: 'junit', version: '4.9'
-}
 
-// See https://github.com/JetBrains/gradle-intellij-plugin/
-intellij {
-    version.set("2024.2")
-    updateSinceUntilBuild.set(false)
-    type.set("IC")
-    plugins = ['java']
-}
-
-tasks {
-    patchPluginXml {
-        sinceBuild.set("242.20224")
-        // untilBuild is not set, meaning there's no end version
+intellijPlatform {
+    pluginConfiguration {
+        id = "com.github.setial"
+        name = "JavaDoc"
+        version = "4.1.4"
+        vendor {
+            email = "s.timofiychuk@gmail.com"
+            url = "https://tsergey.github.io/intellij-javadocs/"
+            name = "Sergey Timofiychuk"
+        }
+        ideaVersion {
+            untilBuild = provider { null }
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Jan 31 16:29:09 EET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,17 +1,14 @@
 <idea-plugin>
-    <id>com.github.setial</id>
-    <name>JavaDoc</name>
-    <version>4.1.3</version>
-    <vendor email="s.timofiychuk@gmail.com" url="http://tsergey.github.io/intellij-javadocs/">
-        Sergey Timofiychuk
-    </vendor>
-
     <description><![CDATA[
       Plugin that generates javadocs on java class elements, like field, method, etc.
       Home page: http://tsergey.github.io/intellij-javadocs
       ]]></description>
 
     <change-notes><![CDATA[
+        <h3>Changes in intellij-javadoc-4.1.4</h3>
+        <ul>
+            <li>Compatibility with intellij-idea build 2024.3</li>
+        </ul>
         <h3>Changes in intellij-javadoc-4.1.3</h3>
         <ul>
             <li>Compatibility with intellij-idea build 2024.2</li>

--- a/src/test/java/com/github/setial/intellijjavadocs/generator/impl/MethodJavaDocGeneratorTest.java
+++ b/src/test/java/com/github/setial/intellijjavadocs/generator/impl/MethodJavaDocGeneratorTest.java
@@ -8,18 +8,21 @@ import com.github.setial.intellijjavadocs.model.settings.Mode;
 import com.github.setial.intellijjavadocs.model.settings.Visibility;
 import com.google.common.collect.Sets;
 import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.PsiMethod;
-import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase4;
 import org.junit.Before;
+import org.junit.Test;
 
+import static com.intellij.openapi.application.ActionsKt.runReadAction;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class MethodJavaDocGeneratorTest extends LightJavaCodeInsightFixtureTestCase {
+public class MethodJavaDocGeneratorTest extends LightJavaCodeInsightFixtureTestCase4 {
 
     private MethodJavaDocGenerator methodJavaDocGenerator;
     private PsiElementFactory elementFactory;
@@ -29,76 +32,86 @@ public class MethodJavaDocGeneratorTest extends LightJavaCodeInsightFixtureTestC
     private PsiMethod protectedGetMethod;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUp() {
         methodJavaDocGenerator = new MethodJavaDocGenerator(getProject());
         elementFactory = PsiElementFactory.getInstance(getProject());
         JavaDocConfiguration settings = getProject().getService(JavaDocConfiguration.class);
         generalSettings = settings.getConfiguration().getGeneralSettings();
         generalSettings.setMode(Mode.REPLACE);
-        psiFile = PsiFileFactory.getInstance(getProject()).createFileFromText(
-                "Test.java", JavaFileType.INSTANCE, "public class Test {}");
-        publicGetMethod = elementFactory.createMethodFromText("public String getParam(String param) {}", psiFile);
-        protectedGetMethod = elementFactory.createMethodFromText("protected String getParam(String param) {}", psiFile);
+        PsiFileFactory fileFactory = PsiFileFactory.getInstance(getProject());
+        psiFile = runReadAction(() -> fileFactory.createFileFromText(
+                "Test.java", JavaFileType.INSTANCE, "public class Test {}"));
+        publicGetMethod = runReadAction(() -> elementFactory.createMethodFromText("public String getParam(String param) {}", psiFile));
+        protectedGetMethod = runReadAction(() -> elementFactory.createMethodFromText("protected String getParam(String param) {}", psiFile));
     }
 
+    @Test
     public void testGenerateJavaDoc() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.METHOD, Level.TYPE));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE, Visibility.PROTECTED, Visibility.PUBLIC));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(publicGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(publicGetMethod));
         assertThat(javaDoc, notNullValue());
     }
 
+    @Test
     public void testGenerateJavaDoc_NoPublicVisibility() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.METHOD, Level.TYPE));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE, Visibility.PROTECTED));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(publicGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(publicGetMethod));
         assertThat(javaDoc, nullValue());
     }
 
+    @Test
     public void testGenerateJavaDoc_NoMethodLevel() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.TYPE));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE, Visibility.PROTECTED, Visibility.PUBLIC));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(publicGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(publicGetMethod));
         assertThat(javaDoc, nullValue());
     }
 
+    @Test
     public void testGenerateJavaDoc_NoMethodLevelAndPublicVisibility() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.TYPE));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE, Visibility.PROTECTED));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(publicGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(publicGetMethod));
         assertThat(javaDoc, nullValue());
     }
 
+    @Test
     public void testGenerateJavaDocProtected() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.TYPE, Level.METHOD));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE, Visibility.PROTECTED));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(protectedGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(protectedGetMethod));
         assertThat(javaDoc, notNullValue());
     }
 
+    @Test
     public void testGenerateJavaDocProtected_NoProtectedVisibility() {
         generalSettings.setLevels(
                 Sets.immutableEnumSet(Level.FIELD, Level.TYPE, Level.METHOD));
         generalSettings.setVisibilities(
                 Sets.immutableEnumSet(Visibility.DEFAULT, Visibility.PRIVATE));
 
-        JavaDoc javaDoc = methodJavaDocGenerator.generateJavaDoc(protectedGetMethod);
+        JavaDoc javaDoc = runReadAction(() -> methodJavaDocGenerator.generateJavaDoc(protectedGetMethod));
         assertThat(javaDoc, nullValue());
+    }
+
+    private Project getProject() {
+        return getFixture().getProject();
     }
 }


### PR DESCRIPTION
Hi!

The main goal of this PR was to enable support of 2024.3 releases, I took the liberty to refactor the build scripts, too.

The PR contains the following:
- add support for IntelliJ IDEA 2024.3 (main feature)
- migrate to intellij gradle plugin 2.x, refactoring the build scripts; one could go even further in this direction
- bump gradle and java versions accordingly (java to 21, this is a requirement of the intellij platform; had to bump gradle version, too)
- refactor tests; migrated to the junit-4-based "Light" tests. They are quite slow to run on my machine, maybe there is some configuration missing.

Please feel free to review/comment/edit/reject some parts of this PR. I tested this build on my local IntelliJ, everything seems fine for now.

Cheers!