### PR TITLE
fix Remove JDOM normalization to prevent unwanted spaces in date formats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build and Release
+
+on:
+  # 1. 常规开发：推送到 master/main 分支时只进行构建测试
+  push:
+    branches: [ "master", "main" ]
+    # 2. 发布触发：只有推送以 'v' 开头的 tag 时（如 v4.1.4），才触发发布流程
+    tags:
+      - "v*"
+  pull_request:
+    branches: [ "master", "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    # ⚠️ 关键权限：必须允许 Action 写入仓库内容，否则无法创建 Release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # 执行构建
+      - name: Build with Gradle
+        run: ./gradlew buildPlugin
+
+      # --- 下面是发布相关的步骤 ---
+
+      # 1. 无论是不是 Tag，先传一份到 Artifacts 备用（方便调试）
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intellij-javadocs-build
+          path: build/distributions/*.zip
+          retention-days: 2
+
+      # 2. 只有当前是 Tag 推送时，才创建 Release 并上传 zip
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/') # 只有打 tag 时才运行这一步
+        with:
+          # 自动把 build/distributions 下的 zip 文件上传到 Release
+          files: build/distributions/*.zip
+          # 自动根据 commit 生成更新日志
+          generate_release_notes: true
+          #如果想要草稿状态，设为 true
+          draft: false
+          prerelease: false

--- a/src/main/java/com/github/setial/intellijjavadocs/utils/JavaDocUtils.java
+++ b/src/main/java/com/github/setial/intellijjavadocs/utils/JavaDocUtils.java
@@ -5,6 +5,7 @@ import com.github.setial.intellijjavadocs.model.JavaDocTag;
 import com.github.setial.intellijjavadocs.transformation.JavaDocBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementFactory;
+import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.impl.source.javadoc.PsiDocMethodOrFieldRef;
 import com.intellij.psi.impl.source.javadoc.PsiDocParamRef;
 import com.intellij.psi.impl.source.javadoc.PsiDocTagValueImpl;
@@ -214,8 +215,11 @@ public class JavaDocUtils {
         String value = null;
         for (PsiElement element : docTag.getDataElements()) {
             if (element instanceof PsiDocTagValue) {
-                value = element.getText();
-                break;
+                PsiElement nextSibling = element.getNextSibling();
+                if (nextSibling == null || nextSibling instanceof PsiWhiteSpace) {
+                    value = element.getText();
+                    break;
+                }
             }
         }
         return value;


### PR DESCRIPTION
**Fix Logic:**
Updated the `findDocTagValue` method to include a validation check: an extracted `value` is now considered valid only if it is immediately followed by a whitespace character (or the end of the tag). If the potential `value` is followed by non-whitespace characters (such as `/` or `-`), it is not extracted as a separate `value` (returning `null`) and is instead preserved as part of the `description`. This prevents `JavaDocBuilder` from inserting unwanted spaces during reconstruction, resolving the issue where date and copyright strings were incorrectly split.